### PR TITLE
fixes #2 of not showing recent commands on typing historie

### DIFF
--- a/history.js
+++ b/history.js
@@ -10,7 +10,9 @@ module.exports = hint => {
 
     const fuse = new Fuse(historyMap, options)
     const matchingHistory = fuse.search(hint)
-    const choices = unique(matchingHistory.map(h => h.command))
+
+    let choices = unique(matchingHistory.map(h => h.command))
+    choices = choices.filter((c) => c);
 
     if (!choices.length) resolve(history)
     else resolve(choices)


### PR DESCRIPTION
I checked and problem was that `hint` was empty when typing `historie`. So filtering commands with empty `hint` was returning empty choices. I added a check when `hint` is empty then i just resolve it with recent 8 commands. Check this out below:
<img width="1199" alt="screen shot 2017-07-15 at 2 40 48 pm" src="https://user-images.githubusercontent.com/12872177/28238374-a66e7bfc-696b-11e7-9e69-a8aeec50fee2.png">
